### PR TITLE
Joystick worker

### DIFF
--- a/features/README.md
+++ b/features/README.md
@@ -8,6 +8,57 @@ specific action based on what it finds. Currently the things it looks for are as
 This just indicates whether video streaming support is available on the vehicle. Solex uses it to determine whether to display the 
 Video screen when the flight screen is opened. An example of reporting this is in the `video` feature in this directory.
 
+## `joystick`
+
+Indicates CC-level joystick support. When present, Solex will listen for events coming from an external joystick controller (e.g. XBox, etc) and 
+send events from that device to the worker specified in `worker_id` in the feature. The relevant event types are `key_event` and `motion_event`.
+
+### `motion_event`
+
+Here are the fields in a `motion_event`:
+
+| id | Description | Range |
+| `s_l_x`| Left Stick left/right (yaw)   | -1 to 1 |
+| `s_l_y`| Left Stick up/down (throttle) | -1 to 1 |
+| `s_r_x`| Right Stick left/right (roll)   | -1 to 1 |
+| `s_r_y`| Right Stick up/down (pitch) | -1 to 1 |
+| `dp_x`| DPad left/right | -1 to 1 |
+| `dp_y`| DPad up/down | -1 to 1 |
+| `tr_l`| Left trigger | 0 to 1 |
+| `tr_r`| Right trigger | 0 to 1 |
+
+To avoid overwhelming the websocket connection with a ton of data, only changed values 
+are sent in a joystick message. So if you move the right stick around, you'll see messages like this:
+
+```
+{"s_r_x" :0.17647064, "s_r_y": 0.20000005, "id": "on_motion_event"}
+```
+
+None of the un-changed values are sent in this case.
+
+### `key_event`
+
+Key events are sent when one of the buttons on the controller is pressed. They have the following identifiers:
+
+| id | keyCode | Description |
+|button_l1|102|Left top/front button|
+|button_l2|104|Left bottom/trigger button|
+|button_r1|103|Right top/front button|
+|button_r2|105|Right bottom/trigger button|
+|button_thumb_l|106|Left stick press down|
+|button_thumb_r|107|Right stick press down|
+|button_y|100|Y button|
+|button_x|99|X button|
+|button_a|96|A button|
+|button_b|97|B button|
+
+These are sent in the `key_event` event specified in the `feature` for the joystick worker. So if you specify that as (eg) `on_key_event`, you'll
+see a message like this when a button is pressed on the controller:
+
+```
+{"name":"button_y","code":100,"id":"on_key_event"}
+```
+
 ## `mission`
 
 Indicates CC-level mission support. When a worker reports mission support, Solex will send a JSON-encoded version of the mission to it

--- a/features/joystick/worker.js
+++ b/features/joystick/worker.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const ATTRS = {
+    id: "joystick",
+    // Name/description
+    name: "Joystick support",
+    description: "Joystick support",
+    // Does this worker want to loop?
+    looper: false,
+    // Mavlink messages we're interested in
+    mavlinkMessages: []
+};
+
+const VERBOSE = true;
+
+function d(str) {
+    if(!VERBOSE) return;
+
+    if(process.mainModule === module) {
+        console.log(str);
+    } else {
+        ATTRS.log(ATTRS.id, str);
+    }
+}
+
+function getAttributes() {
+    return ATTRS;
+}
+
+function loop() {
+}
+
+function onLoad() {
+    d("onLoad()");
+}
+
+function onUnload() {
+    d("onUnload()");
+}
+
+function onMavlinkMessage(msg) { }
+
+function onGCSMessage(msg) {
+    // d(`onGCSMessage(): msg.id=${msg.id}`);
+
+    const result = {
+        ok: true
+    };
+
+    switch(msg.id) {
+        case "on_key_event": {
+            onKeyEvent(msg);
+            break;
+        }
+
+        case "on_motion_event": {
+            onMotionEvent(msg);
+            break;
+        }
+    }
+
+    return result;
+}
+
+function onKeyEvent(msg) {
+    d(JSON.stringify(msg));
+}
+
+function onMotionEvent(msg) {
+    d(JSON.stringify(msg));
+}
+
+function onRosterChanged() {
+    d("Roster has been changed");
+}
+
+function onBroadcastResponse(msg) {
+    // d(`onBroadcastResponse(${JSON.stringify(msg)}`);
+
+    if(msg.request) {
+        switch(msg.request.type) {
+            case "mission_item_support": {
+
+                if(msg.response) {
+                    if(!mMissionItemSupportWorkers) mMissionItemSupportWorkers = [];
+
+                    mMissionItemSupportWorkers.push(msg.response);
+                }
+
+                break;
+            }
+        }
+    }
+}
+
+function getFeatures() {
+    d("getFeatures()");
+
+    var output = {
+        // Indicate this worker supports missions
+        joystick: { 
+            worker_id: ATTRS.id,
+            key_event: "on_key_event",
+            motion_event: "on_motion_event"
+        }
+    };
+
+    return output;
+}
+
+exports.getAttributes = getAttributes;
+exports.loop = loop;
+exports.onLoad = onLoad;
+exports.onUnload = onUnload;
+exports.onMavlinkMessage = onMavlinkMessage;
+exports.onGCSMessage = onGCSMessage;
+exports.onRosterChanged = onRosterChanged;
+exports.getFeatures = getFeatures;
+exports.onBroadcastResponse = onBroadcastResponse;
+
+if(process.mainModule === module) {
+    d("Hi!");
+}


### PR DESCRIPTION
Allows a worker to advertise that it wants joystick input
from the GCS, and to handle it. Details in README.md.